### PR TITLE
feat: P0/P1 realtime mapselect sync, vote policy hardening, and UI consistency

### DIFF
--- a/src/main/java/com/phasetranscrystal/fpsmatch/FPSMatch.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/FPSMatch.java
@@ -197,6 +197,7 @@ public class FPSMatch {
         PACKET_REGISTER.registerPacket(OpenSpawnPointToolScreenS2CPacket.class);
         PACKET_REGISTER.registerPacket(SpawnPointToolActionC2SPacket.class);
         PACKET_REGISTER.registerPacket(OpenMapSelectionC2SPacket.class);
+        PACKET_REGISTER.registerPacket(CloseMapViewC2SPacket.class);
         PACKET_REGISTER.registerPacket(MapSelectionAccessS2CPacket.class);
         PACKET_REGISTER.registerPacket(MapSelectionSnapshotS2CPacket.class);
         PACKET_REGISTER.registerPacket(MapRoomActionC2SPacket.class);

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/client/net/FPSMClientPacketHandlers.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/client/net/FPSMClientPacketHandlers.java
@@ -198,7 +198,11 @@ public final class FPSMClientPacketHandlers {
     public static void handleMapSelectionSnapshot(MapSelectionSnapshotS2CPacket packet) {
         FPSMClient.getGlobalData().setMapSelectionSnapshot(packet);
         FPSMClient.getGlobalData().setMapSelectionButtonVisible(packet.viewerOp() || packet.nonOpButtonEnabled());
-        FPSMMapSelectScreens.openSelection(packet);
+        if (packet.passive()) {
+            FPSMMapSelectScreens.applySelectionIfOpen(packet);
+        } else {
+            FPSMMapSelectScreens.openSelection(packet);
+        }
     }
 
     public static void handleMapSelectionAccess(MapSelectionAccessS2CPacket packet) {
@@ -207,7 +211,11 @@ public final class FPSMClientPacketHandlers {
 
     public static void handleMapRoomDetail(MapRoomDetailS2CPacket packet) {
         FPSMClient.getGlobalData().setMapRoomDetail(packet.detail());
-        FPSMMapSelectScreens.openDetail(packet);
+        if (packet.passive()) {
+            FPSMMapSelectScreens.applyDetailIfOpen(packet.detail());
+        } else {
+            FPSMMapSelectScreens.openDetail(packet);
+        }
     }
 
     public static void handleMapRoomReadyState(MapRoomReadyStateS2CPacket packet) {

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/EditShopSlotScreen.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/EditShopSlotScreen.java
@@ -64,8 +64,8 @@ public class EditShopSlotScreen extends AbstractContainerScreen<EditShopSlotMenu
         this.priceField.setValue(String.valueOf(menu.getPrice()));
         this.priceField.setFilter(s -> s.matches("\\d*"));
         this.priceField.setResponder(s -> this.data.set(1, s.isEmpty() ? 0 : Integer.parseInt(s)));
-        this.priceField.setTextColor(0xFFE2E8F0);
-        this.priceField.setTextColorUneditable(0xFF8F9AA3);
+        this.priceField.setTextColor(FPSMGuiTheme.TEXT_BODY);
+        this.priceField.setTextColorUneditable(FPSMGuiTheme.TEXT_DISABLED);
         this.priceField.setBordered(true);
         this.priceField.setEditable(true);
         this.addRenderableWidget(this.priceField);
@@ -76,8 +76,8 @@ public class EditShopSlotScreen extends AbstractContainerScreen<EditShopSlotMenu
         this.groupField.setValue(String.valueOf(menu.getGroupId()));
         this.groupField.setFilter(s -> s.matches("-?\\d*"));
         this.groupField.setResponder(s -> data.set(2, s.isEmpty() ? -1 : Integer.parseInt(s)));
-        this.groupField.setTextColor(0xFFE2E8F0);
-        this.groupField.setTextColorUneditable(0xFF8F9AA3);
+        this.groupField.setTextColor(FPSMGuiTheme.TEXT_BODY);
+        this.groupField.setTextColorUneditable(FPSMGuiTheme.TEXT_DISABLED);
         this.groupField.setBordered(true);
         this.groupField.setEditable(true);
         this.addRenderableWidget(this.groupField);
@@ -96,8 +96,8 @@ public class EditShopSlotScreen extends AbstractContainerScreen<EditShopSlotMenu
         this.ammoField.setValue(String.valueOf(menu.getAmmo()));
         this.ammoField.setFilter(s -> s.matches("\\d*"));
         this.ammoField.setResponder(s -> data.set(0, s.isEmpty() ? 0 : Integer.parseInt(s)));
-        this.ammoField.setTextColor(0xFFE2E8F0);
-        this.ammoField.setTextColorUneditable(0xFF8F9AA3);
+        this.ammoField.setTextColor(FPSMGuiTheme.TEXT_BODY);
+        this.ammoField.setTextColorUneditable(FPSMGuiTheme.TEXT_DISABLED);
         this.ammoField.setBordered(true);
         this.ammoField.setEditable(true);
         this.addRenderableWidget(this.ammoField);

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/FPSMTeamManageScreen.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/FPSMTeamManageScreen.java
@@ -129,8 +129,8 @@ public class FPSMTeamManageScreen extends FPSMMapScreenBase implements FPSMMapDe
 
     private int teamColor(String teamName) {
         return switch (teamName.toLowerCase(Locale.ROOT)) {
-            case "ct" -> 0xFF4080FF;
-            case "t" -> 0xFFFFC040;
+            case "ct" -> FPSMGuiTheme.TEAM_CT;
+            case "t" -> FPSMGuiTheme.TEAM_T;
             default -> FPSMGuiTheme.TEXT_SUB;
         };
     }

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/MapCreatorToolScreen.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/MapCreatorToolScreen.java
@@ -1,6 +1,7 @@
 package com.phasetranscrystal.fpsmatch.common.client.screen;
 
 import com.phasetranscrystal.fpsmatch.FPSMatch;
+import com.phasetranscrystal.fpsmatch.common.client.screen.mapselect.FPSMGuiTheme;
 import com.phasetranscrystal.fpsmatch.common.item.MapCreatorTool;
 import com.phasetranscrystal.fpsmatch.common.item.tool.ToolInteractionAction;
 import com.phasetranscrystal.fpsmatch.common.packet.MapCreatorToolActionC2SPacket;
@@ -30,9 +31,10 @@ import java.util.List;
 public class MapCreatorToolScreen extends Screen {
     private static final int PANEL_WIDTH = 300;
     private static final int PANEL_HEIGHT = 226;
-    private static final int SCREEN_OVERLAY = 0x5A000000;
-    private static final int PANEL_BACKGROUND = 0xD0191D22;
-    private static final int PANEL_BORDER = 0xFF7DA3B8;
+    // 统一设计 Token：遮罩/面板/边框全部引用 FPSMGuiTheme（原青色边框改为主题中性边框）
+    private static final int SCREEN_OVERLAY = FPSMGuiTheme.BG_SHADOW;
+    private static final int PANEL_BACKGROUND = FPSMGuiTheme.BG_PANEL;
+    private static final int PANEL_BORDER = FPSMGuiTheme.BORDER_INNER;
 
     private List<String> availableTypes;
     private List<OpenMapCreatorToolScreenS2CPacket.MapEntry> maps;

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/MatchConfigToolScreen.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/MatchConfigToolScreen.java
@@ -1,6 +1,7 @@
 package com.phasetranscrystal.fpsmatch.common.client.screen;
 
 import com.phasetranscrystal.fpsmatch.FPSMatch;
+import com.phasetranscrystal.fpsmatch.common.client.screen.mapselect.FPSMGuiTheme;
 import com.phasetranscrystal.fpsmatch.common.packet.MatchConfigToolActionC2SPacket;
 import com.phasetranscrystal.fpsmatch.common.packet.OpenMatchConfigToolScreenS2CPacket;
 import com.phasetranscrystal.fpsmatch.common.packet.mapselect.MapRoomSettingInfo;
@@ -17,17 +18,18 @@ import java.util.List;
 import java.util.Objects;
 
 public class MatchConfigToolScreen extends Screen {
-    private static final int PANEL_BACKGROUND = 0xE0181C22;
-    private static final int PANEL_BORDER = 0xFF7DA3B8;
-    private static final int ROW_BACKGROUND = 0x80252B33;
-    private static final int ROW_HOVER = 0xA0344150;
-    private static final int TEXT_MAIN = 0xFFEAF2F6;
-    private static final int TEXT_SUB = 0xFF9EB2BD;
-    private static final int TEXT_DISABLED = 0xFF6F7D86;
+    // 统一设计 Token：颜色全部引用 FPSMGuiTheme，消除与主界面割裂的私有色板
+    private static final int PANEL_BACKGROUND = FPSMGuiTheme.BG_PANEL;
+    private static final int PANEL_BORDER = FPSMGuiTheme.BORDER_INNER;
+    private static final int ROW_BACKGROUND = FPSMGuiTheme.ROW_NORMAL;
+    private static final int ROW_HOVER = FPSMGuiTheme.ROW_HOVER;
+    private static final int TEXT_MAIN = FPSMGuiTheme.TEXT_BODY;
+    private static final int TEXT_SUB = FPSMGuiTheme.TEXT_SUB;
+    private static final int TEXT_DISABLED = FPSMGuiTheme.TEXT_DISABLED;
     private static final int ROW_HEIGHT = 25;
     private static final int TOP = 28;
     private static final int FIELD_WIDTH = 126;
-    private static final int BUTTON_HEIGHT = 20;
+    private static final int BUTTON_HEIGHT = FPSMGuiTheme.BUTTON_HEIGHT;
 
     private OpenMatchConfigToolScreenS2CPacket data;
     private final List<EditBox> valueFields = new ArrayList<>();

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/SpawnPointToolScreen.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/SpawnPointToolScreen.java
@@ -1,6 +1,7 @@
 package com.phasetranscrystal.fpsmatch.common.client.screen;
 
 import com.phasetranscrystal.fpsmatch.FPSMatch;
+import com.phasetranscrystal.fpsmatch.common.client.screen.mapselect.FPSMGuiTheme;
 import com.phasetranscrystal.fpsmatch.common.packet.OpenSpawnPointToolScreenS2CPacket;
 import com.phasetranscrystal.fpsmatch.common.packet.SpawnPointToolActionC2SPacket;
 import com.phasetranscrystal.fpsmatch.core.data.SpawnPointData;
@@ -16,9 +17,10 @@ import java.util.List;
 public class SpawnPointToolScreen extends Screen {
     private static final int PANEL_WIDTH = 326;
     private static final int PANEL_HEIGHT = 220;
-    private static final int SCREEN_OVERLAY = 0x5A000000;
-    private static final int PANEL_BACKGROUND = 0xD0191D22;
-    private static final int PANEL_BORDER = 0xFFB58A42;
+    // 统一设计 Token：遮罩/面板/边框全部引用 FPSMGuiTheme（原金色边框改为主题中性边框）
+    private static final int SCREEN_OVERLAY = FPSMGuiTheme.BG_SHADOW;
+    private static final int PANEL_BACKGROUND = FPSMGuiTheme.BG_PANEL;
+    private static final int PANEL_BORDER = FPSMGuiTheme.BORDER_INNER;
 
     private List<String> availableTypes;
     private List<String> availableMaps;

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/mapselect/FPSMGuiTheme.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/mapselect/FPSMGuiTheme.java
@@ -64,6 +64,12 @@ public final class FPSMGuiTheme {
     /** 在线绿（与等待中同色系） */
     public static final int ST_ONLINE = 0xFF74E084;
 
+    // ===== 队伍色 =====
+    /** 队伍色：CT 蓝 */
+    public static final int TEAM_CT = 0xFF4080FF;
+    /** 队伍色：T 金 */
+    public static final int TEAM_T = 0xFFFFC040;
+
     // ===== 强调色 =====
     /** 品牌蓝（选中条、主按钮） */
     public static final int ACCENT_PRIMARY = 0xFF4A9EFF;

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/mapselect/FPSMMapDetailScreen.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/mapselect/FPSMMapDetailScreen.java
@@ -218,6 +218,12 @@ public class FPSMMapDetailScreen extends FPSMMapScreenBase implements FPSMMapDet
 
     @Override
     public void onClose() {
+        // 返回列表时重新订阅列表并刷新；若关闭到非地图界面则退订。
+        if (parent instanceof FPSMMapSelectionScreen) {
+            FPSMatch.sendToServer(new OpenMapSelectionC2SPacket());
+        } else {
+            FPSMatch.sendToServer(new com.phasetranscrystal.fpsmatch.common.packet.mapselect.CloseMapViewC2SPacket());
+        }
         minecraft.setScreen(parent);
     }
 

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/mapselect/FPSMMapSelectScreens.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/mapselect/FPSMMapSelectScreens.java
@@ -30,6 +30,29 @@ public final class FPSMMapSelectScreens {
         }
     }
 
+    /**
+     * 被动详情更新：仅当当前已打开详情/子界面时原地刷新，绝不强制打开界面。
+     * 用于订阅式广播，避免对局内玩家被弹出 GUI。
+     */
+    public static void applyDetailIfOpen(com.phasetranscrystal.fpsmatch.common.packet.mapselect.MapRoomDetail detail) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.screen instanceof FPSMMapDetailScreen screen) {
+            screen.applyDetail(detail);
+        } else if (minecraft.screen instanceof FPSMMapDetailChildScreen screen) {
+            screen.applyDetail(detail);
+        }
+    }
+
+    /**
+     * 被动列表更新：仅当当前已打开列表界面时原地刷新，绝不强制打开界面。
+     */
+    public static void applySelectionIfOpen(MapSelectionSnapshotS2CPacket packet) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.screen instanceof FPSMMapSelectionScreen screen) {
+            screen.applySnapshot(packet);
+        }
+    }
+
     public static void openChild(Screen child) {
         Minecraft.getInstance().setScreen(child);
     }

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/mapselect/FPSMMapSelectionScreen.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/client/screen/mapselect/FPSMMapSelectionScreen.java
@@ -105,6 +105,7 @@ public class FPSMMapSelectionScreen extends FPSMMapScreenBase {
 
     @Override
     public void onClose() {
+        FPSMatch.sendToServer(new com.phasetranscrystal.fpsmatch.common.packet.mapselect.CloseMapViewC2SPacket());
         minecraft.setScreen(parent);
     }
 

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/event/FPSMEventHook.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/event/FPSMEventHook.java
@@ -92,6 +92,7 @@ public class FPSMEventHook {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void onPlayerLoggedOutEvent(PlayerEvent.PlayerLoggedOutEvent event) {
         if (event.getEntity() instanceof ServerPlayer player) {
+            com.phasetranscrystal.fpsmatch.common.mapselect.MapRoomSyncManager.unwatch(player.getUUID());
             Optional<BaseMap> opt = FPSMCore.getInstance().getMapByPlayer(player);
             boolean leave = true;
             if (opt.isPresent()) {

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/mapselect/MapRoomSyncManager.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/mapselect/MapRoomSyncManager.java
@@ -1,0 +1,227 @@
+package com.phasetranscrystal.fpsmatch.common.mapselect;
+
+import com.phasetranscrystal.fpsmatch.FPSMatch;
+import com.phasetranscrystal.fpsmatch.common.packet.mapselect.MapRoomDetailS2CPacket;
+import com.phasetranscrystal.fpsmatch.common.packet.mapselect.MapSelectionSnapshotS2CPacket;
+import com.phasetranscrystal.fpsmatch.config.FPSMConfig;
+import com.phasetranscrystal.fpsmatch.core.FPSMCore;
+import com.phasetranscrystal.fpsmatch.core.data.PlayerData;
+import com.phasetranscrystal.fpsmatch.core.data.Setting;
+import com.phasetranscrystal.fpsmatch.core.map.BaseMap;
+import com.phasetranscrystal.fpsmatch.core.team.ServerTeam;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 地图选择界面的“订阅式事件驱动”同步管理器（服务端）。
+ * 取代原先“打开/手动刷新才拉取一次”的纯 PULL 模型：
+ * 玩家打开房间列表 → 订阅 LIST；打开某房间详情 → 订阅该房间 DETAIL。
+ * 每 {@code RoomSyncIntervalTicks} tick 计算一次房间/列表的轻量签名，只有在
+ * 数据实际发生变化时，才向“正在观看该数据”的订阅者广播一次被动(passive)快照。
+ * 通过“订阅者集合 + 签名 dirty 检测”双重约束，既保证准实时，又避免对局内玩家收到
+ * 无关 GUI 弹出、并把带宽/CPU 开销压到最低（无人观看时直接短路返回）。
+ * 本机制受 {@link FPSMConfig.Server#roomSyncPushEnabled} 控制，关闭后完全回退旧行为。
+ */
+public final class MapRoomSyncManager {
+    /** 观看列表的哨兵目标值（区别于具体房间 key）。 */
+    private static final String LIST_TARGET = "\u0000list";
+    private static final String KEY_SEPARATOR = "\u001f";
+
+    /** 玩家 UUID -> 观看目标（LIST_TARGET 或 房间 key）。同一玩家同一时刻只观看一个目标。 */
+    private static final Map<UUID, String> WATCHERS = new ConcurrentHashMap<>();
+    /** 房间 key -> 上次广播时的签名，用于 dirty 检测。 */
+    private static final Map<String, Long> LAST_ROOM_SIGNATURE = new ConcurrentHashMap<>();
+
+    private static long lastListSignature = Long.MIN_VALUE;
+    private static int tickCounter = 0;
+
+    private MapRoomSyncManager() {
+    }
+
+    public static String roomKey(String gameType, String mapName) {
+        return gameType + KEY_SEPARATOR + mapName;
+    }
+
+    public static String roomKey(BaseMap map) {
+        return roomKey(map.getGameType(), map.getMapName());
+    }
+
+    /** 订阅房间列表视图。 */
+    public static void watchList(UUID player) {
+        if (player != null) {
+            WATCHERS.put(player, LIST_TARGET);
+        }
+    }
+
+    /** 订阅指定房间详情视图。 */
+    public static void watchDetail(UUID player, String gameType, String mapName) {
+        if (player != null) {
+            WATCHERS.put(player, roomKey(gameType, mapName));
+        }
+    }
+
+    /** 退订（玩家关闭界面/登出）。 */
+    public static void unwatch(UUID player) {
+        if (player != null) {
+            WATCHERS.remove(player);
+        }
+    }
+
+    /** 全局 tick 入口，由 {@link FPSMCore#onServerTick()} 在所有地图 tick 之后调用。 */
+    public static void tick(MinecraftServer server) {
+        if (server == null || !FPSMConfig.Server.roomSyncPushEnabled.get()) {
+            return;
+        }
+        if (WATCHERS.isEmpty() || !FPSMCore.initialized()) {
+            return;
+        }
+        int interval = Math.max(1, FPSMConfig.Server.roomSyncIntervalTicks.get());
+        if (++tickCounter < interval) {
+            return;
+        }
+        tickCounter = 0;
+
+        flushList(server);
+        flushDetails(server);
+    }
+
+    private static void flushList(MinecraftServer server) {
+        boolean anyListWatcher = WATCHERS.containsValue(LIST_TARGET);
+        if (!anyListWatcher) {
+            return;
+        }
+        long signature = computeListSignature();
+        if (signature == lastListSignature) {
+            return;
+        }
+        lastListSignature = signature;
+
+        boolean nonOpButtonEnabled = FPSMConfig.Server.enableMapSelectionButtonForNonOps.get();
+        for (Map.Entry<UUID, String> entry : WATCHERS.entrySet()) {
+            if (!LIST_TARGET.equals(entry.getValue())) {
+                continue;
+            }
+            ServerPlayer player = server.getPlayerList().getPlayer(entry.getKey());
+            if (player == null) {
+                continue;
+            }
+            boolean viewerOp = MapRoomQueryService.isMapOperator(player);
+            FPSMatch.sendToPlayer(player, new MapSelectionSnapshotS2CPacket(
+                    MapRoomQueryService.summaries(player), viewerOp, nonOpButtonEnabled, true));
+        }
+    }
+
+    private static void flushDetails(MinecraftServer server) {
+        Set<String> watchedRooms = new HashSet<>(WATCHERS.values());
+        watchedRooms.remove(LIST_TARGET);
+        if (watchedRooms.isEmpty()) {
+            return;
+        }
+        int maxWatchers = Math.max(1, FPSMConfig.Server.roomSyncMaxWatchersPerRoom.get());
+
+        for (String key : watchedRooms) {
+            BaseMap map = findMapByKey(key);
+            if (map == null) {
+                LAST_ROOM_SIGNATURE.remove(key);
+                continue;
+            }
+            long signature = computeRoomSignature(map);
+            Long last = LAST_ROOM_SIGNATURE.get(key);
+            if (last != null && last == signature) {
+                continue;
+            }
+            LAST_ROOM_SIGNATURE.put(key, signature);
+
+            int sent = 0;
+            for (Map.Entry<UUID, String> entry : WATCHERS.entrySet()) {
+                if (!key.equals(entry.getValue())) {
+                    continue;
+                }
+                if (sent >= maxWatchers) {
+                    break;
+                }
+                ServerPlayer player = server.getPlayerList().getPlayer(entry.getKey());
+                if (player == null) {
+                    continue;
+                }
+                FPSMatch.sendToPlayer(player, new MapRoomDetailS2CPacket(MapRoomQueryService.detail(player, map), true));
+                sent++;
+            }
+        }
+    }
+
+    private static BaseMap findMapByKey(String key) {
+        int idx = key.indexOf(KEY_SEPARATOR);
+        if (idx < 0) {
+            return null;
+        }
+        String gameType = key.substring(0, idx);
+        String mapName = key.substring(idx + KEY_SEPARATOR.length());
+        return MapRoomQueryService.findMap(gameType, mapName).orElse(null);
+    }
+
+    /** 轻量列表签名：与房间数变化、人数、开始/调试/可加入状态相关，顺序无关累加。 */
+    private static long computeListSignature() {
+        long acc = 0L;
+        for (Map.Entry<String, java.util.List<BaseMap>> entry : FPSMCore.getInstance().getAllMaps().entrySet()) {
+            for (BaseMap map : entry.getValue()) {
+                long h = map.getGameType().hashCode();
+                h = h * 31 + map.getMapName().hashCode();
+                h = h * 31 + map.getMapTeams().getJoinedUUID().size();
+                h = h * 31 + (map.isStart() ? 1 : 0);
+                h = h * 31 + (map.isDebug() ? 1 : 0);
+                h = h * 31 + (map.allowJoinInProgress() ? 1 : 0);
+                acc += h;
+            }
+        }
+        return acc;
+    }
+
+    /** 轻量房间签名：玩家/队伍/在线/准备/设置/开始/调试/倒计时变化即变化，玩家顺序无关。 */
+    private static long computeRoomSignature(BaseMap map) {
+        long sig = 1469598103934665603L;
+        sig = mix(sig, map.isStart() ? 1 : 0);
+        sig = mix(sig, map.isDebug() ? 1 : 0);
+        sig = mix(sig, map.getReadyCountdownSeconds());
+
+        long playersAcc = 0L;
+        for (ServerTeam team : map.getMapTeams().getTeamsWithSpectator()) {
+            int teamHash = team.getName().hashCode();
+            for (PlayerData data : team.getPlayersData()) {
+                long ph = data.getOwner().hashCode();
+                ph = ph * 31 + teamHash;
+                ph = ph * 31 + (data.getPlayer().isPresent() ? 1 : 0);
+                ph = ph * 31 + (map.isReady(data.getOwner()) ? 1 : 0);
+                playersAcc += ph;
+            }
+        }
+        sig = mix(sig, playersAcc);
+
+        for (Setting<?> setting : map.settings()) {
+            sig = mix(sig, setting.getConfigName().hashCode());
+            Object value = setting.get();
+            sig = mix(sig, value == null ? 0 : value.hashCode());
+        }
+        return sig;
+    }
+
+    private static long mix(long sig, long value) {
+        sig ^= value;
+        sig *= 1099511628211L;
+        return sig;
+    }
+
+    /** 服务器停止/重载时清理，避免跨会话脏状态。 */
+    public static void clear() {
+        WATCHERS.clear();
+        LAST_ROOM_SIGNATURE.clear();
+        lastListSignature = Long.MIN_VALUE;
+        tickCounter = 0;
+    }
+}

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/packet/mapselect/CloseMapViewC2SPacket.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/packet/mapselect/CloseMapViewC2SPacket.java
@@ -1,0 +1,31 @@
+package com.phasetranscrystal.fpsmatch.common.packet.mapselect;
+
+import com.phasetranscrystal.fpsmatch.common.mapselect.MapRoomSyncManager;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+/**
+ * 客户端关闭地图选择/房间界面时发送，用于从 {@link MapRoomSyncManager} 退订，
+ * 避免服务端向已离开界面的玩家继续计算/广播被动同步包。
+ */
+public record CloseMapViewC2SPacket() {
+    public static void encode(CloseMapViewC2SPacket packet, FriendlyByteBuf buf) {
+    }
+
+    public static CloseMapViewC2SPacket decode(FriendlyByteBuf buf) {
+        return new CloseMapViewC2SPacket();
+    }
+
+    public void handle(Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> {
+            ServerPlayer player = ctx.get().getSender();
+            if (player != null) {
+                MapRoomSyncManager.unwatch(player.getUUID());
+            }
+        });
+        ctx.get().setPacketHandled(true);
+    }
+}

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/packet/mapselect/MapRoomActionC2SPacket.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/packet/mapselect/MapRoomActionC2SPacket.java
@@ -85,6 +85,9 @@ public record MapRoomActionC2SPacket(Action action, String gameType, String mapN
                 case REQUEST_DETAIL -> throw new IllegalStateException("REQUEST_DETAIL handled before action dispatch");
             };
             MapRoomActionService.sendMessage(player, result);
+            if (result.success() && result.detail().isPresent() && action != Action.LEAVE) {
+                com.phasetranscrystal.fpsmatch.common.mapselect.MapRoomSyncManager.watchDetail(player.getUUID(), gameType, mapName);
+            }
             result.detail().ifPresentOrElse(
                     detail -> FPSMatch.sendToPlayer(player, new MapRoomDetailS2CPacket(detail)),
                     () -> FPSMatch.sendToPlayer(player, new MapRoomToastS2CPacket(result.message(), !result.success()))
@@ -95,7 +98,10 @@ public record MapRoomActionC2SPacket(Action action, String gameType, String mapN
 
     private void sendDetail(ServerPlayer player) {
         MapRoomQueryService.findMap(gameType, mapName).ifPresentOrElse(
-                map -> FPSMatch.sendToPlayer(player, new MapRoomDetailS2CPacket(MapRoomQueryService.detail(player, map))),
+                map -> {
+                    FPSMatch.sendToPlayer(player, new MapRoomDetailS2CPacket(MapRoomQueryService.detail(player, map)));
+                    com.phasetranscrystal.fpsmatch.common.mapselect.MapRoomSyncManager.watchDetail(player.getUUID(), gameType, mapName);
+                },
                 () -> FPSMatch.sendToPlayer(player, new MapRoomToastS2CPacket(Component.translatable("gui.fpsm.map_select.action.map_not_found"), true))
         );
     }

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/packet/mapselect/MapRoomDetailS2CPacket.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/packet/mapselect/MapRoomDetailS2CPacket.java
@@ -6,13 +6,21 @@ import net.minecraftforge.network.NetworkEvent;
 
 import java.util.function.Supplier;
 
-public record MapRoomDetailS2CPacket(MapRoomDetail detail) {
+public record MapRoomDetailS2CPacket(MapRoomDetail detail, boolean passive) {
+    /**
+     * 主动(active)详情包：会在客户端未打开界面时强制打开详情界面（原有行为）。
+     */
+    public MapRoomDetailS2CPacket(MapRoomDetail detail) {
+        this(detail, false);
+    }
+
     public static void encode(MapRoomDetailS2CPacket packet, FriendlyByteBuf buf) {
         MapRoomDetail.encode(packet.detail(), buf);
+        buf.writeBoolean(packet.passive());
     }
 
     public static MapRoomDetailS2CPacket decode(FriendlyByteBuf buf) {
-        return new MapRoomDetailS2CPacket(MapRoomDetail.decode(buf));
+        return new MapRoomDetailS2CPacket(MapRoomDetail.decode(buf), buf.readBoolean());
     }
 
     public void handle(Supplier<NetworkEvent.Context> ctx) {

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/packet/mapselect/MapRoomSettingsC2SPacket.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/packet/mapselect/MapRoomSettingsC2SPacket.java
@@ -31,6 +31,9 @@ public record MapRoomSettingsC2SPacket(String gameType, String mapName, String s
             }
             MapRoomActionService.Result result = MapRoomActionService.setSetting(player, gameType, mapName, settingName, value);
             MapRoomActionService.sendMessage(player, result);
+            if (result.success() && result.detail().isPresent()) {
+                com.phasetranscrystal.fpsmatch.common.mapselect.MapRoomSyncManager.watchDetail(player.getUUID(), gameType, mapName);
+            }
             result.detail().ifPresentOrElse(
                     detail -> FPSMatch.sendToPlayer(player, new MapRoomDetailS2CPacket(detail)),
                     () -> FPSMatch.sendToPlayer(player, new MapRoomToastS2CPacket(result.message(), !result.success()))

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/packet/mapselect/MapSelectionSnapshotS2CPacket.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/packet/mapselect/MapSelectionSnapshotS2CPacket.java
@@ -8,16 +8,25 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
-public record MapSelectionSnapshotS2CPacket(List<MapRoomSummary> maps, boolean viewerOp, boolean nonOpButtonEnabled) {
+public record MapSelectionSnapshotS2CPacket(List<MapRoomSummary> maps, boolean viewerOp, boolean nonOpButtonEnabled, boolean passive) {
+    /**
+     * 主动(active)快照包：会在客户端未打开界面时强制打开地图选择界面（原有行为）。
+     */
+    public MapSelectionSnapshotS2CPacket(List<MapRoomSummary> maps, boolean viewerOp, boolean nonOpButtonEnabled) {
+        this(maps, viewerOp, nonOpButtonEnabled, false);
+    }
+
     public static void encode(MapSelectionSnapshotS2CPacket packet, FriendlyByteBuf buf) {
         buf.writeCollection(packet.maps(), (buffer, summary) -> MapRoomSummary.encode(summary, buffer));
         buf.writeBoolean(packet.viewerOp());
         buf.writeBoolean(packet.nonOpButtonEnabled());
+        buf.writeBoolean(packet.passive());
     }
 
     public static MapSelectionSnapshotS2CPacket decode(FriendlyByteBuf buf) {
         return new MapSelectionSnapshotS2CPacket(
                 buf.readCollection(ArrayList::new, MapRoomSummary::decode),
+                buf.readBoolean(),
                 buf.readBoolean(),
                 buf.readBoolean()
         );

--- a/src/main/java/com/phasetranscrystal/fpsmatch/common/packet/mapselect/OpenMapSelectionC2SPacket.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/common/packet/mapselect/OpenMapSelectionC2SPacket.java
@@ -31,6 +31,7 @@ public record OpenMapSelectionC2SPacket() {
                 return;
             }
             FPSMatch.sendToPlayer(player, new MapSelectionSnapshotS2CPacket(MapRoomQueryService.summaries(player), viewerOp, nonOpButtonEnabled));
+            com.phasetranscrystal.fpsmatch.common.mapselect.MapRoomSyncManager.watchList(player.getUUID());
         });
         ctx.get().setPacketHandled(true);
     }

--- a/src/main/java/com/phasetranscrystal/fpsmatch/config/FPSMConfig.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/config/FPSMConfig.java
@@ -17,6 +17,10 @@ public class FPSMConfig {
         public static ForgeConfigSpec.BooleanValue disableRenderHeadShotHitBox;
         public static ForgeConfigSpec.BooleanValue enableMapSelectionButtonForNonOps;
 
+        public static ForgeConfigSpec.BooleanValue roomSyncPushEnabled;
+        public static ForgeConfigSpec.IntValue roomSyncIntervalTicks;
+        public static ForgeConfigSpec.IntValue roomSyncMaxWatchersPerRoom;
+
         public static void init(ForgeConfigSpec.Builder builder) {
             lock3PersonCamera = builder.comment(
                     "禁用第三人称"
@@ -53,6 +57,29 @@ public class FPSMConfig {
                     "允许非 OP 玩家在 ESC 暂停界面看到 FPSMatch 地图选择按钮",
                     "Allow non-OP players to see the FPSMatch map selection button in the ESC pause screen"
             ).define("EnableMapSelectionButtonForNonOps", true);
+
+            builder.comment(
+                    "房间/地图选择界面实时同步（订阅式事件驱动）",
+                    "Room / map-selection UI live sync (subscription-based, event-driven)"
+            ).push("roomSync");
+
+            roomSyncPushEnabled = builder.comment(
+                    "启用后：房间数据变化时主动向正在观看的客户端广播，实现准实时刷新；",
+                    "关闭后回退到旧的“打开/手动刷新才拉取一次”行为。",
+                    "When enabled, room changes are pushed to viewers for near-realtime UI; disabled falls back to legacy pull-on-open."
+            ).define("RoomSyncPushEnabled", true);
+
+            roomSyncIntervalTicks = builder.comment(
+                    "服务端合并/广播变更的间隔(tick)。越小越实时越耗带宽，20=每秒一次。",
+                    "Server dirty-scan / broadcast interval in ticks. Smaller = more realtime & more bandwidth."
+            ).defineInRange("RoomSyncIntervalTicks", 10, 1, 100);
+
+            roomSyncMaxWatchersPerRoom = builder.comment(
+                    "单个房间单次广播的最大接收者数量，防止大厅广播风暴。",
+                    "Max recipients per room per broadcast, to prevent lobby broadcast storms."
+            ).defineInRange("RoomSyncMaxWatchersPerRoom", 64, 1, 512);
+
+            builder.pop();
         }
 
     }

--- a/src/main/java/com/phasetranscrystal/fpsmatch/core/FPSMCore.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/core/FPSMCore.java
@@ -222,12 +222,14 @@ public class FPSMCore {
                 map.reset();
             }
         }));
+        com.phasetranscrystal.fpsmatch.common.mapselect.MapRoomSyncManager.tick(getServer());
     }
 
     protected void clearData(){
         GAMES.clear();
         REGISTRY.clear();
         playerToMapCache.clear();
+        com.phasetranscrystal.fpsmatch.common.mapselect.MapRoomSyncManager.clear();
     }
 
     public static void checkAndLeaveTeam(ServerPlayer player){

--- a/src/main/java/com/phasetranscrystal/fpsmatch/core/map/VoteObj.java
+++ b/src/main/java/com/phasetranscrystal/fpsmatch/core/map/VoteObj.java
@@ -15,12 +15,35 @@ public class VoteObj {
     private final Set<UUID> eligiblePlayers = new HashSet<>();
     private final Runnable onSuccess;
     private final Runnable onFailure;
+    private final TimeoutPolicy timeoutPolicy;
+    private final AbstentionPolicy abstentionPolicy;
     private VoteStatus status = VoteStatus.ONGOING;
     private boolean executed = false;
 
     // 投票状态枚举
     public enum VoteStatus {
         ONGOING, SUCCESS, FAILED
+    }
+
+    /**
+     * 投票超时结算策略。
+     *   {@link #FAIL} —— 超时一律判失败（历史默认行为）。
+     *   {@link #PASS_IF_MAJORITY} —— 超时时按“已投票玩家的严格多数”结算，避免多数赞成却因超时被否决。
+     *
+     */
+    public enum TimeoutPolicy {
+        FAIL, PASS_IF_MAJORITY
+    }
+
+    /**
+     * 弃权计票策略。
+     * 
+     *   {@link #COUNT_AS_NO} —— 弃权视为反对：门槛分母为全部在线有资格者（历史默认行为）。
+     *   {@link #IGNORE} —— 弃权忽略：超时结算时分母只算已投票人数。
+     * 
+     */
+    public enum AbstentionPolicy {
+        COUNT_AS_NO, IGNORE
     }
 
     /**
@@ -34,12 +57,25 @@ public class VoteObj {
      */
     public VoteObj(String voteTitle, Component message, int duration, float requiredPercent,
                    Runnable onSuccess, Runnable onFailure, Collection<UUID> eligiblePlayers) {
+        this(voteTitle, message, duration, requiredPercent, onSuccess, onFailure, eligiblePlayers,
+                TimeoutPolicy.FAIL, AbstentionPolicy.COUNT_AS_NO);
+    }
+
+    /**
+     * 带超时/弃权策略的完整构造。旧的 7 参构造会以 {@link TimeoutPolicy#FAIL} +
+     * {@link AbstentionPolicy#COUNT_AS_NO} 委托到此处，保证向后兼容。
+     */
+    public VoteObj(String voteTitle, Component message, int duration, float requiredPercent,
+                   Runnable onSuccess, Runnable onFailure, Collection<UUID> eligiblePlayers,
+                   TimeoutPolicy timeoutPolicy, AbstentionPolicy abstentionPolicy) {
         this.endVoteTimer = System.currentTimeMillis() + duration * 1000L;
         this.voteTitle = voteTitle;
         this.message = message;
         this.requiredPercent = Math.min(Math.max(requiredPercent, 0f), 1f); // 确保在0-1范围内
         this.onSuccess = onSuccess;
         this.onFailure = onFailure;
+        this.timeoutPolicy = timeoutPolicy == null ? TimeoutPolicy.FAIL : timeoutPolicy;
+        this.abstentionPolicy = abstentionPolicy == null ? AbstentionPolicy.COUNT_AS_NO : abstentionPolicy;
         this.eligiblePlayers.addAll(eligiblePlayers);
     }
 
@@ -84,40 +120,93 @@ public class VoteObj {
             return true; // 投票已结束或已执行回调
         }
 
-        int totalEligiblePlayers = getEligiblePlayerCount();
+        int eligibleOnline = getEligiblePlayerCount();
 
         // 检查是否有资格投票的玩家
-        if (totalEligiblePlayers == 0) {
+        if (eligibleOnline == 0) {
             status = VoteStatus.FAILED;
             executeCallback();
             return true;
         }
 
-        // 计算当前同意票比例
-        long agreeCount = voteResults.values().stream().filter(Boolean::booleanValue).count();
-        float currentRatio = (float) agreeCount / totalEligiblePlayers;
+        // 仅统计在线玩家的票，避免掉线者导致分子/分母口径不一致（历史上可能出现比例 > 1）
+        int agree = onlineAgreeCount();
+        int voted = onlineVotedCount();
 
-        // 检查是否所有有资格的玩家都已投票
-        boolean allVoted = voteResults.size() >= totalEligiblePlayers;
-
-        // 检查是否已达到通过比例
-        boolean passed = currentRatio >= requiredPercent;
-
-        // 如果所有玩家已投票或已达到通过比例，则结束投票
-        if (allVoted || passed) {
-            status = passed ? VoteStatus.SUCCESS : VoteStatus.FAILED;
+        // 提前通过：赞成票占“全部在线有资格者”的比例已达门槛，无论其余人如何投都已锁定通过
+        if ((float) agree / eligibleOnline >= requiredPercent) {
+            status = VoteStatus.SUCCESS;
             executeCallback();
             return true;
         }
 
-        // 检查是否超时
+        // 所有在线有资格者都投完但未达门槛 -> 失败
+        if (voted >= eligibleOnline) {
+            status = VoteStatus.FAILED;
+            executeCallback();
+            return true;
+        }
+
+        // 超时：按配置的超时/弃权策略结算
         if (System.currentTimeMillis() >= endVoteTimer) {
-            status = VoteStatus.FAILED;
+            status = resolveTimeout(agree, voted, eligibleOnline) ? VoteStatus.SUCCESS : VoteStatus.FAILED;
             executeCallback();
             return true;
         }
 
         return false;
+    }
+
+    /**
+     * 超时结算：根据 {@link TimeoutPolicy} 与 {@link AbstentionPolicy} 判断是否通过。
+     */
+    private boolean resolveTimeout(int agree, int voted, int eligibleOnline) {
+        if (timeoutPolicy == TimeoutPolicy.PASS_IF_MAJORITY) {
+            int disagree = voted - agree;
+            return agree > disagree; // 已投票中的严格多数
+        }
+        // FAIL 策略：仍尊重弃权口径——IGNORE 时分母只算已投票人数
+        int denominator = abstentionPolicy == AbstentionPolicy.IGNORE ? voted : eligibleOnline;
+        return denominator > 0 && (float) agree / denominator >= requiredPercent;
+    }
+
+    private boolean isOnline(UUID player) {
+        return FPSMCore.getInstance().getPlayerByUUID(player).isPresent();
+    }
+
+    private int onlineAgreeCount() {
+        int count = 0;
+        for (Map.Entry<UUID, Boolean> entry : voteResults.entrySet()) {
+            if (Boolean.TRUE.equals(entry.getValue()) && isOnline(entry.getKey())) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private int onlineVotedCount() {
+        int count = 0;
+        for (UUID player : voteResults.keySet()) {
+            if (isOnline(player)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /** 当前在线的同意票数（供投票 HUD 展示，口径与结算一致）。 */
+    public int getOnlineAgreeCount() {
+        return onlineAgreeCount();
+    }
+
+    /** 当前在线的反对票数。 */
+    public int getOnlineDisagreeCount() {
+        return onlineVotedCount() - onlineAgreeCount();
+    }
+
+    /** 当前在线的已投票人数。 */
+    public int getOnlineVotedCount() {
+        return onlineVotedCount();
     }
 
     /**
@@ -143,8 +232,7 @@ public class VoteObj {
             }
         } catch (Exception e) {
             // 记录回调执行异常，避免影响主线程
-            System.err.println("Vote callback execution failed: " + e.getMessage());
-            e.printStackTrace();
+            com.phasetranscrystal.fpsmatch.FPSMatch.LOGGER.error("Vote callback execution failed for '{}'", voteTitle, e);
         }
     }
 


### PR DESCRIPTION
## Summary
- Implement P0 realtime room list/detail synchronization with watcher lifecycle and tick-based dirty flush.
- Add passive snapshot/detail packet mode so background updates no longer force-open map UI.
- Extend vote core timeout/abstention policy and online-count based decision path while keeping legacy constructor compatibility.
- Apply P2 editor/mapselect theme consistency updates without breaking existing screen flow.

## Key Changes
- Added server sync manager and close-view unsubscribe flow.
- Extended mapselect S2C packets with backward-compatible passive flag.
- Updated client handlers/screens to apply updates only when target UI is open.
- Added configurable room sync knobs under server config.
- Improved VoteObj timeout behavior for online-player ratio correctness.

## Compatibility
- Backward-compatible constructors retained for updated packets and vote object.
- Existing gameplay/UI flows remain available; updates are additive and gated.

## Verification
- Gradle compile/test passed locally in FPSMatch.
- Integrated downstream build/test path also passed after BlockOffensive integration.
